### PR TITLE
Add OIDC provider integration and demo page

### DIFF
--- a/deno.json
+++ b/deno.json
@@ -2,7 +2,8 @@
   "nodeModulesDir": "auto",
   "workspace": [
     "server",
-    "hono-middleware"
+    "hono-middleware",
+    "dpop"
   ],
   "unstable": ["bundle", "kv"]
 }

--- a/deno.lock
+++ b/deno.lock
@@ -3,6 +3,7 @@
   "specifiers": {
     "jsr:@std/assert@*": "1.0.14",
     "jsr:@std/assert@1": "1.0.14",
+    "jsr:@std/encoding@1.0.10": "1.0.10",
     "jsr:@std/internal@^1.0.10": "1.0.10",
     "npm:@hexagon/base64@^2.0.4": "2.0.4",
     "npm:@simplewebauthn/browser@^13.2.0": "13.2.0",
@@ -23,6 +24,9 @@
       "dependencies": [
         "jsr:@std/internal"
       ]
+    },
+    "@std/encoding@1.0.10": {
+      "integrity": "8783c6384a2d13abd5e9e87a7ae0520a30e9f56aeeaa3bdf910a3eaaf5c811a1"
     },
     "@std/internal@1.0.10": {
       "integrity": "e3be62ce42cab0e177c27698e5d9800122f67b766a0bea6ca4867886cbde8cf7"
@@ -641,6 +645,12 @@
   },
   "workspace": {
     "members": {
+      "dpop": {
+        "dependencies": [
+          "jsr:@std/assert@1",
+          "jsr:@std/encoding@1.0.10"
+        ]
+      },
       "hono-middleware": {
         "dependencies": [
           "jsr:@std/assert@1",

--- a/deno.lock
+++ b/deno.lock
@@ -8,8 +8,14 @@
     "npm:@simplewebauthn/browser@^13.2.0": "13.2.0",
     "npm:@simplewebauthn/server@13": "13.2.1",
     "npm:@types/node@*": "24.2.0",
+    "npm:@types/oidc-provider@*": "9.5.0",
+    "npm:@whatwg-node/server@*": "0.10.12",
+    "npm:@whatwg-node/server@~0.10.12": "0.10.12",
     "npm:hono@*": "4.9.8",
-    "npm:hono@^4.3.10": "4.9.8"
+    "npm:hono@^4.3.10": "4.9.8",
+    "npm:koa@*": "3.0.1",
+    "npm:oidc-provider@*": "9.5.1",
+    "npm:oidc-provider@^9.5.1": "9.5.1"
   },
   "jsr": {
     "@std/assert@1.0.14": {
@@ -23,11 +29,36 @@
     }
   },
   "npm": {
+    "@envelop/instrumentation@1.0.0": {
+      "integrity": "sha512-cxgkB66RQB95H3X27jlnxCRNTmPuSTgmBAq6/4n2Dtv4hsk4yz8FadA1ggmd0uZzvKqWD6CR+WFgTjhDqg7eyw==",
+      "dependencies": [
+        "@whatwg-node/promise-helpers",
+        "tslib@2.8.1"
+      ]
+    },
+    "@fastify/busboy@3.2.0": {
+      "integrity": "sha512-m9FVDXU3GT2ITSe0UaMA5rU3QkfC/UXtCU8y0gSN/GugTqtVldOBWIB5V6V3sbmenVZUIpU6f+mPEO2+m5iTaA=="
+    },
     "@hexagon/base64@1.1.28": {
       "integrity": "sha512-lhqDEAvWixy3bZ+UOYbPwUbBkwBq5C1LAJ/xPC8Oi+lL54oyakv/npbA0aU2hgCsx/1NUd4IBvV03+aUBWxerw=="
     },
     "@hexagon/base64@2.0.4": {
       "integrity": "sha512-H/ZY6rGyaEuk0mwQgZ3BVi9hMjFTYpBNFbmtOuec/pPibuGhCMXd8fGtwBaO0h44FkWMurysMsDrpkJsBRmoWQ=="
+    },
+    "@koa/cors@5.0.0": {
+      "integrity": "sha512-x/iUDjcS90W69PryLDIMgFyV21YLTnG9zOpPXS7Bkt2b8AsY3zZsIpOLBkYr9fBcF3HbkKaER5hOBZLfpLgYNw==",
+      "dependencies": [
+        "vary"
+      ]
+    },
+    "@koa/router@14.0.0": {
+      "integrity": "sha512-LBSu5K0qAaaQcXX/0WIB9PGDevyCxxpnc1uq13vV/CgObaVxuis5hKl3Eboq/8gcb6ebnkAStW9NB/Em2eYyFA==",
+      "dependencies": [
+        "debug",
+        "http-errors@2.0.0",
+        "koa-compose",
+        "path-to-regexp"
+      ]
     },
     "@levischuck/tiny-cbor@0.2.11": {
       "integrity": "sha512-llBRm4dT4Z89aRsm6u2oEZ8tfwL/2l6BwpZ7JcyieouniDECM5AqNgr/y08zalEIvW3RSK4upYyybDcmjXqAow=="
@@ -168,10 +199,164 @@
         "@peculiar/x509"
       ]
     },
+    "@types/accepts@1.3.7": {
+      "integrity": "sha512-Pay9fq2lM2wXPWbteBsRAGiWH2hig4ZE2asK+mm7kUzlxRTfL961rj89I6zV/E3PcIkDqyuBEcMxFT7rccugeQ==",
+      "dependencies": [
+        "@types/node"
+      ]
+    },
+    "@types/body-parser@1.19.6": {
+      "integrity": "sha512-HLFeCYgz89uk22N5Qg3dvGvsv46B8GLvKKo1zKG4NybA8U2DiEO3w9lqGg29t/tfLRJpJ6iQxnVw4OnB7MoM9g==",
+      "dependencies": [
+        "@types/connect",
+        "@types/node"
+      ]
+    },
+    "@types/connect@3.4.38": {
+      "integrity": "sha512-K6uROf1LD88uDQqJCktA4yzL1YYAK6NgfsI0v/mTgyPKWsX1CnJ0XPSDhViejru1GcRkLWb8RlzFYJRqGUbaug==",
+      "dependencies": [
+        "@types/node"
+      ]
+    },
+    "@types/content-disposition@0.5.9": {
+      "integrity": "sha512-8uYXI3Gw35MhiVYhG3s295oihrxRyytcRHjSjqnqZVDDy/xcGBRny7+Xj1Wgfhv5QzRtN2hB2dVRBUX9XW3UcQ=="
+    },
+    "@types/cookies@0.9.1": {
+      "integrity": "sha512-E/DPgzifH4sM1UMadJMWd6mO2jOd4g1Ejwzx8/uRCDpJis1IrlyQEcGAYEomtAqRYmD5ORbNXMeI9U0RiVGZbg==",
+      "dependencies": [
+        "@types/connect",
+        "@types/express",
+        "@types/keygrip",
+        "@types/node"
+      ]
+    },
+    "@types/express-serve-static-core@5.0.7": {
+      "integrity": "sha512-R+33OsgWw7rOhD1emjU7dzCDHucJrgJXMA5PYCzJxVil0dsyx5iBEPHqpPfiKNJQb7lZ1vxwoLR4Z87bBUpeGQ==",
+      "dependencies": [
+        "@types/node",
+        "@types/qs",
+        "@types/range-parser",
+        "@types/send"
+      ]
+    },
+    "@types/express@5.0.3": {
+      "integrity": "sha512-wGA0NX93b19/dZC1J18tKWVIYWyyF2ZjT9vin/NRu0qzzvfVzWjs04iq2rQ3H65vCTQYlRqs3YHfY7zjdV+9Kw==",
+      "dependencies": [
+        "@types/body-parser",
+        "@types/express-serve-static-core",
+        "@types/serve-static"
+      ]
+    },
+    "@types/http-assert@1.5.6": {
+      "integrity": "sha512-TTEwmtjgVbYAzZYWyeHPrrtWnfVkm8tQkP8P21uQifPgMRgjrow3XDEYqucuC8SKZJT7pUnhU/JymvjggxO9vw=="
+    },
+    "@types/http-errors@2.0.5": {
+      "integrity": "sha512-r8Tayk8HJnX0FztbZN7oVqGccWgw98T/0neJphO91KkmOzug1KkofZURD4UaD5uH8AqcFLfdPErnBod0u71/qg=="
+    },
+    "@types/keygrip@1.0.6": {
+      "integrity": "sha512-lZuNAY9xeJt7Bx4t4dx0rYCDqGPW8RXhQZK1td7d4H6E9zYbLoOtjBvfwdTKpsyxQI/2jv+armjX/RW+ZNpXOQ=="
+    },
+    "@types/koa-compose@3.2.8": {
+      "integrity": "sha512-4Olc63RY+MKvxMwVknCUDhRQX1pFQoBZ/lXcRLP69PQkEpze/0cr8LNqJQe5NFb/b19DWi2a5bTi2VAlQzhJuA==",
+      "dependencies": [
+        "@types/koa"
+      ]
+    },
+    "@types/koa@3.0.0": {
+      "integrity": "sha512-MOcVYdVYmkSutVHZZPh8j3+dAjLyR5Tl59CN0eKgpkE1h/LBSmPAsQQuWs+bKu7WtGNn+hKfJH9Gzml+PulmDg==",
+      "dependencies": [
+        "@types/accepts",
+        "@types/content-disposition",
+        "@types/cookies",
+        "@types/http-assert",
+        "@types/http-errors",
+        "@types/keygrip",
+        "@types/koa-compose",
+        "@types/node"
+      ]
+    },
+    "@types/mime@1.3.5": {
+      "integrity": "sha512-/pyBZWSLD2n0dcHE3hq8s8ZvcETHtEuF+3E7XVt0Ig2nvsVQXdghHVcEkIWjy9A0wKfTn97a/PSDYohKIlnP/w=="
+    },
     "@types/node@24.2.0": {
       "integrity": "sha512-3xyG3pMCq3oYCNg7/ZP+E1ooTaGB4cG8JWRsqqOYQdbWNY4zbaV0Ennrd7stjiJEFZCaybcIgpTjJWHRfBSIDw==",
       "dependencies": [
         "undici-types"
+      ]
+    },
+    "@types/oidc-provider@9.5.0": {
+      "integrity": "sha512-eEzCRVTSqIHD9Bo/qRJ4XQWQ5Z/zBcG+Z2cGJluRsSuWx1RJihqRyPxhIEpMXTwPzHYRTQkVp7hwisQOwzzSAg==",
+      "dependencies": [
+        "@types/keygrip",
+        "@types/koa",
+        "@types/node"
+      ]
+    },
+    "@types/qs@6.14.0": {
+      "integrity": "sha512-eOunJqu0K1923aExK6y8p6fsihYEn/BYuQ4g0CxAAgFc4b/ZLN4CrsRZ55srTdqoiLzU2B2evC+apEIxprEzkQ=="
+    },
+    "@types/range-parser@1.2.7": {
+      "integrity": "sha512-hKormJbkJqzQGhziax5PItDUTMAM9uE2XXQmM37dyd4hVM+5aVl7oVxMVUiVQn2oCQFN/LKCZdvSM0pFRqbSmQ=="
+    },
+    "@types/send@0.17.5": {
+      "integrity": "sha512-z6F2D3cOStZvuk2SaP6YrwkNO65iTZcwA2ZkSABegdkAh/lf+Aa/YQndZVfmEXT5vgAp6zv06VQ3ejSVjAny4w==",
+      "dependencies": [
+        "@types/mime",
+        "@types/node"
+      ]
+    },
+    "@types/serve-static@1.15.8": {
+      "integrity": "sha512-roei0UY3LhpOJvjbIP6ZZFngyLKl5dskOtDhxY5THRSpO+ZI+nzJ+m5yUMzGrp89YRa7lvknKkMYjqQFGwA7Sg==",
+      "dependencies": [
+        "@types/http-errors",
+        "@types/node",
+        "@types/send"
+      ]
+    },
+    "@whatwg-node/disposablestack@0.0.6": {
+      "integrity": "sha512-LOtTn+JgJvX8WfBVJtF08TGrdjuFzGJc4mkP8EdDI8ADbvO7kiexYep1o8dwnt0okb0jYclCDXF13xU7Ge4zSw==",
+      "dependencies": [
+        "@whatwg-node/promise-helpers",
+        "tslib@2.8.1"
+      ]
+    },
+    "@whatwg-node/fetch@0.10.11": {
+      "integrity": "sha512-eR8SYtf9Nem1Tnl0IWrY33qJ5wCtIWlt3Fs3c6V4aAaTFLtkEQErXu3SSZg/XCHrj9hXSJ8/8t+CdMk5Qec/ZA==",
+      "dependencies": [
+        "@whatwg-node/node-fetch",
+        "urlpattern-polyfill"
+      ]
+    },
+    "@whatwg-node/node-fetch@0.8.0": {
+      "integrity": "sha512-+z00GpWxKV/q8eMETwbdi80TcOoVEVZ4xSRkxYOZpn3kbV3nej5iViNzXVke/j3v4y1YpO5zMS/CVDIASvJnZQ==",
+      "dependencies": [
+        "@fastify/busboy",
+        "@whatwg-node/disposablestack",
+        "@whatwg-node/promise-helpers",
+        "tslib@2.8.1"
+      ]
+    },
+    "@whatwg-node/promise-helpers@1.3.2": {
+      "integrity": "sha512-Nst5JdK47VIl9UcGwtv2Rcgyn5lWtZ0/mhRQ4G8NN2isxpq2TO30iqHzmwoJycjWuyUfg3GFXqP/gFHXeV57IA==",
+      "dependencies": [
+        "tslib@2.8.1"
+      ]
+    },
+    "@whatwg-node/server@0.10.12": {
+      "integrity": "sha512-MQIvvQyPvKGna586MzXhgwnEbGtbm7QtOgJ/KPd/tC70M/jbhd1xHdIQQbh3okBw+MrDF/EvaC2vB5oRC7QdlQ==",
+      "dependencies": [
+        "@envelop/instrumentation",
+        "@whatwg-node/disposablestack",
+        "@whatwg-node/fetch",
+        "@whatwg-node/promise-helpers",
+        "tslib@2.8.1"
+      ]
+    },
+    "accepts@1.3.8": {
+      "integrity": "sha512-PYAthTa2m2VKxuvSD3DPC/Gy+U+sOA1LAuT8mkmRuvw+NACSaeXEQ+NHcVF7rONl6qcaxV3Uuemwawk+7+SJLw==",
+      "dependencies": [
+        "mime-types@2.1.35",
+        "negotiator"
       ]
     },
     "asn1js@3.0.6": {
@@ -182,8 +367,196 @@
         "tslib@2.8.1"
       ]
     },
+    "bytes@3.1.2": {
+      "integrity": "sha512-/Nf7TyzTx6S3yRJObOAV7956r8cr2+Oj8AC5dt8wSP3BQAoeX58NoHyCU8P8zGkNXStjTSi6fzO6F0pBdcYbEg=="
+    },
+    "content-disposition@0.5.4": {
+      "integrity": "sha512-FveZTNuGw04cxlAiWbzi6zTAL/lhehaWbTtgluJh4/E95DqMwTmha3KZN1aAWA8cFIhHzMZUvLevkw5Rqk+tSQ==",
+      "dependencies": [
+        "safe-buffer"
+      ]
+    },
+    "content-type@1.0.5": {
+      "integrity": "sha512-nTjqfcBFEipKdXCv4YDQWCfmcLZKm81ldF0pAopTvyrFGVbcR6P/VAAd5G7N+0tTr8QqiU0tFadD6FK4NtJwOA=="
+    },
+    "cookies@0.9.1": {
+      "integrity": "sha512-TG2hpqe4ELx54QER/S3HQ9SRVnQnGBtKUz5bLQWtYAQ+o6GpgMs6sYUvaiJjVxb+UXwhRhAEP3m7LbsIZ77Hmw==",
+      "dependencies": [
+        "depd@2.0.0",
+        "keygrip"
+      ]
+    },
+    "debug@4.4.3": {
+      "integrity": "sha512-RGwwWnwQvkVfavKVt22FGLw+xYSdzARwm0ru6DhTVA3umU5hZc28V3kO4stgYryrTlLpuvgI9GiijltAjNbcqA==",
+      "dependencies": [
+        "ms"
+      ]
+    },
+    "deep-equal@1.0.1": {
+      "integrity": "sha512-bHtC0iYvWhyaTzvV3CZgPeZQqCOBGyGsVV7v4eevpdkLHfiSrXUdBG+qAuSz4RI70sszvjQ1QSZ98An1yNwpSw=="
+    },
+    "delegates@1.0.0": {
+      "integrity": "sha512-bd2L678uiWATM6m5Z1VzNCErI3jiGzt6HGY8OVICs40JQq/HALfbyNJmp0UDakEY4pMMaN0Ly5om/B1VI/+xfQ=="
+    },
+    "depd@1.1.2": {
+      "integrity": "sha512-7emPTl6Dpo6JRXOXjLRxck+FlLRX5847cLKEn00PLAgc3g2hTZZgr+e4c2v6QpSmLeFP3n5yUo7ft6avBK/5jQ=="
+    },
+    "depd@2.0.0": {
+      "integrity": "sha512-g7nH6P6dyDioJogAAGprGpCtVImJhpPk/roCzdb3fIh61/s/nPsfR6onyMwkCAR/OlC3yBC0lESvUoQEAssIrw=="
+    },
+    "destroy@1.2.0": {
+      "integrity": "sha512-2sJGJTaXIIaR1w4iJSNoN0hnMY7Gpc/n8D4qSCJw8QqFWXf7cuAgnEHxBpweaVcPevC2l3KpjYCx3NypQQgaJg=="
+    },
+    "ee-first@1.1.1": {
+      "integrity": "sha512-WMwm9LhRUo+WUaRN+vRuETqG89IgZphVSNkdFgeb6sS/E4OrDIN7t48CAewSHXc6C8lefD8KKfr5vY61brQlow=="
+    },
+    "encodeurl@2.0.0": {
+      "integrity": "sha512-Q0n9HRi4m6JuGIV1eFlmvJB7ZEVxu93IrMyiMsGC0lrMJMWzRgx6WGquyfQgZVb31vhGgXnfmPNNXmxnOkRBrg=="
+    },
+    "escape-html@1.0.3": {
+      "integrity": "sha512-NiSupZ4OeuGwr68lGIeym/ksIZMJodUGOSCZ/FSnTxcrekbvqrgdUxlJOMpijaKZVjAJrWrGs/6Jy8OMuyj9ow=="
+    },
+    "eta@3.5.0": {
+      "integrity": "sha512-e3x3FBvGzeCIHhF+zhK8FZA2vC5uFn6b4HJjegUbIWrDb4mJ7JjTGMJY9VGIbRVpmSwHopNiaJibhjIr+HfLug=="
+    },
+    "fresh@0.5.2": {
+      "integrity": "sha512-zJ2mQYM18rEFOudeV4GShTGIQ7RbzA7ozbU9I/XBpm7kqgMywgmylMwXHxZJmkVoYkna9d2pVXVXPdYTP9ej8Q=="
+    },
     "hono@4.9.8": {
       "integrity": "sha512-JW8Bb4RFWD9iOKxg5PbUarBYGM99IcxFl2FPBo2gSJO11jjUDqlP1Bmfyqt8Z/dGhIQ63PMA9LdcLefXyIasyg=="
+    },
+    "http-assert@1.5.0": {
+      "integrity": "sha512-uPpH7OKX4H25hBmU6G1jWNaqJGpTXxey+YOUizJUAgu0AjLUeC8D73hTrhvDS5D+GJN1DN1+hhc/eF/wpxtp0w==",
+      "dependencies": [
+        "deep-equal",
+        "http-errors@1.8.1"
+      ]
+    },
+    "http-errors@1.8.1": {
+      "integrity": "sha512-Kpk9Sm7NmI+RHhnj6OIWDI1d6fIoFAtFt9RLaTMRlg/8w49juAStsrBgp0Dp4OdxdVbRIeKhtCUvoi/RuAhO4g==",
+      "dependencies": [
+        "depd@1.1.2",
+        "inherits",
+        "setprototypeof",
+        "statuses@1.5.0",
+        "toidentifier"
+      ]
+    },
+    "http-errors@2.0.0": {
+      "integrity": "sha512-FtwrG/euBzaEjYeRqOgly7G0qviiXoJWnvEH2Z1plBdXgbyjv34pHTSb9zoeHMyDy33+DWy5Wt9Wo+TURtOYSQ==",
+      "dependencies": [
+        "depd@2.0.0",
+        "inherits",
+        "setprototypeof",
+        "statuses@2.0.1",
+        "toidentifier"
+      ]
+    },
+    "iconv-lite@0.7.0": {
+      "integrity": "sha512-cf6L2Ds3h57VVmkZe+Pn+5APsT7FpqJtEhhieDCvrE2MK5Qk9MyffgQyuxQTm6BChfeZNtcOLHp9IcWRVcIcBQ==",
+      "dependencies": [
+        "safer-buffer"
+      ]
+    },
+    "inherits@2.0.4": {
+      "integrity": "sha512-k/vGaX4/Yla3WzyMCvTQOXYeIHvqOKtnqBduzTHpzpQZzAskKMhZ2K+EnBiSM9zGSoIFeMpXKxa4dYeZIQqewQ=="
+    },
+    "jose@6.1.0": {
+      "integrity": "sha512-TTQJyoEoKcC1lscpVDCSsVgYzUDg/0Bt3WE//WiTPK6uOCQC2KZS4MpugbMWt/zyjkopgZoXhZuCi00gLudfUA=="
+    },
+    "jsesc@3.1.0": {
+      "integrity": "sha512-/sM3dO2FOzXjKQhJuo0Q173wf2KOo8t4I8vHy6lF9poUp7bKT0/NHE8fPX23PwfhnykfqnC2xRxOnVw5XuGIaA==",
+      "bin": true
+    },
+    "keygrip@1.1.0": {
+      "integrity": "sha512-iYSchDJ+liQ8iwbSI2QqsQOvqv58eJCEanyJPJi+Khyu8smkcKSFUCbPwzFcL7YVtZ6eONjqRX/38caJ7QjRAQ==",
+      "dependencies": [
+        "tsscmp"
+      ]
+    },
+    "koa-compose@4.1.0": {
+      "integrity": "sha512-8ODW8TrDuMYvXRwra/Kh7/rJo9BtOfPc6qO8eAfC80CnCvSjSl0bkRM24X6/XBBEyj0v1nRUQ1LyOy3dbqOWXw=="
+    },
+    "koa@3.0.1": {
+      "integrity": "sha512-oDxVkRwPOHhGlxKIDiDB2h+/l05QPtefD7nSqRgDfZt8P+QVYFWjfeK8jANf5O2YXjk8egd7KntvXKYx82wOag==",
+      "dependencies": [
+        "accepts",
+        "content-disposition",
+        "content-type",
+        "cookies",
+        "delegates",
+        "destroy",
+        "encodeurl",
+        "escape-html",
+        "fresh",
+        "http-assert",
+        "http-errors@2.0.0",
+        "koa-compose",
+        "mime-types@3.0.1",
+        "on-finished",
+        "parseurl",
+        "statuses@2.0.2",
+        "type-is",
+        "vary"
+      ]
+    },
+    "media-typer@1.1.0": {
+      "integrity": "sha512-aisnrDP4GNe06UcKFnV5bfMNPBUw4jsLGaWwWfnH3v02GnBuXX2MCVn5RbrWo0j3pczUilYblq7fQ7Nw2t5XKw=="
+    },
+    "mime-db@1.52.0": {
+      "integrity": "sha512-sPU4uV7dYlvtWJxwwxHD0PuihVNiE7TyAbQ5SWxDCB9mUYvOgroQOwYQQOKPJ8CIbE+1ETVlOoK1UC2nU3gYvg=="
+    },
+    "mime-db@1.54.0": {
+      "integrity": "sha512-aU5EJuIN2WDemCcAp2vFBfp/m4EAhWJnUNSSw0ixs7/kXbd6Pg64EmwJkNdFhB8aWt1sH2CTXrLxo/iAGV3oPQ=="
+    },
+    "mime-types@2.1.35": {
+      "integrity": "sha512-ZDY+bPm5zTTF+YpCrAU9nK0UgICYPT0QtT1NZWFv4s++TNkcgVaT0g6+4R2uI4MjQjzysHB1zxuWL50hzaeXiw==",
+      "dependencies": [
+        "mime-db@1.52.0"
+      ]
+    },
+    "mime-types@3.0.1": {
+      "integrity": "sha512-xRc4oEhT6eaBpU1XF7AjpOFD+xQmXNB5OVKwp4tqCuBpHLS/ZbBDrc07mYTDqVMg6PfxUjjNp85O6Cd2Z/5HWA==",
+      "dependencies": [
+        "mime-db@1.54.0"
+      ]
+    },
+    "ms@2.1.3": {
+      "integrity": "sha512-6FlzubTLZG3J2a/NVCAleEhjzq5oxgHyaCU9yYXvcLsvoVaHJq/s5xXI6/XXP6tz7R9xAOtHnSO/tXtF3WRTlA=="
+    },
+    "nanoid@5.1.6": {
+      "integrity": "sha512-c7+7RQ+dMB5dPwwCp4ee1/iV/q2P6aK1mTZcfr1BTuVlyW9hJYiMPybJCcnBlQtuSmTIWNeazm/zqNoZSSElBg==",
+      "bin": true
+    },
+    "negotiator@0.6.3": {
+      "integrity": "sha512-+EUsqGPLsM+j/zdChZjsnX51g4XrHFOIXwfnCVPGlQk/k5giakcKsuxCObBRu6DSm9opw/O6slWbJdghQM4bBg=="
+    },
+    "oidc-provider@9.5.1": {
+      "integrity": "sha512-19Wa4bfz3reoudxrY7sF5SeQKxe5b3dY8hWzQdnBGS87rH0BoYoDDUDRTYciJMN3oI6S02C9xM6vuaHtoZ48eA==",
+      "dependencies": [
+        "@koa/cors",
+        "@koa/router",
+        "debug",
+        "eta",
+        "jose",
+        "jsesc",
+        "koa",
+        "nanoid",
+        "quick-lru",
+        "raw-body"
+      ]
+    },
+    "on-finished@2.4.1": {
+      "integrity": "sha512-oVlzkg3ENAhCk2zdv7IJwd/QUD4z2RxRwpkcGY8psCVcCYZNq4wYnVWALHM+brtuJjePWiYF/ClmuDr8Ch5+kg==",
+      "dependencies": [
+        "ee-first"
+      ]
+    },
+    "parseurl@1.3.3": {
+      "integrity": "sha512-CiyeOxFT/JZyN5m0z9PfXw4SCBJ6Sygz1Dpl0wqjlhDEGGBP1GnsUVEL0p63hoG1fcj3fHynXi9NYO4nWOL+qQ=="
+    },
+    "path-to-regexp@8.3.0": {
+      "integrity": "sha512-7jdwVIRtsP8MYpdXSwOS0YdD0Du+qOoF/AEPIt88PcCFrZCzx41oxku1jD88hZBwbNUIEfpqvuhjFaMAqMTWnA=="
     },
     "pvtsutils@1.3.6": {
       "integrity": "sha512-PLgQXQ6H2FWCaeRak8vvk1GW462lMxB5s3Jm673N82zI4vqtVUPuZdffdZbPDFRoU8kAhItWFtPCWiPpp4/EDg==",
@@ -194,8 +567,41 @@
     "pvutils@1.1.3": {
       "integrity": "sha512-pMpnA0qRdFp32b1sJl1wOJNxZLQ2cbQx+k6tjNtZ8CpvVhNqEPRgivZ2WOUev2YMajecdH7ctUPDvEe87nariQ=="
     },
+    "quick-lru@7.2.0": {
+      "integrity": "sha512-fG4L8TlD1CacJiGMGPxM1/K8l/GaKL2eFQZ6DWAjxZYxSf07DkumbC/Mhh+u/NHvxkfQVL25By0pxBS8QE9ZrQ=="
+    },
+    "raw-body@3.0.1": {
+      "integrity": "sha512-9G8cA+tuMS75+6G/TzW8OtLzmBDMo8p1JRxN5AZ+LAp8uxGA8V8GZm4GQ4/N5QNQEnLmg6SS7wyuSmbKepiKqA==",
+      "dependencies": [
+        "bytes",
+        "http-errors@2.0.0",
+        "iconv-lite",
+        "unpipe"
+      ]
+    },
     "reflect-metadata@0.2.2": {
       "integrity": "sha512-urBwgfrvVP/eAyXx4hluJivBKzuEbSQs9rKWCrCkbSxNv8mxPcUZKeuoF3Uy4mJl3Lwprp6yy5/39VWigZ4K6Q=="
+    },
+    "safe-buffer@5.2.1": {
+      "integrity": "sha512-rp3So07KcdmmKbGvgaNxQSJr7bGVSVk5S9Eq1F+ppbRo70+YeaDxkw5Dd8NPN+GD6bjnYm2VuPuCXmpuYvmCXQ=="
+    },
+    "safer-buffer@2.1.2": {
+      "integrity": "sha512-YZo3K82SD7Riyi0E1EQPojLz7kpepnSQI9IyPbHHg1XXXevb5dJI7tpyN2ADxGcQbHG7vcyRHk0cbwqcQriUtg=="
+    },
+    "setprototypeof@1.2.0": {
+      "integrity": "sha512-E5LDX7Wrp85Kil5bhZv46j8jOeboKq5JMmYM3gVGdGH8xFpPWXUMsNrlODCrkoxMEeNi/XZIwuRvY4XNwYMJpw=="
+    },
+    "statuses@1.5.0": {
+      "integrity": "sha512-OpZ3zP+jT1PI7I8nemJX4AKmAX070ZkYPVWV/AaKTJl+tXCTGyVdC1a4SL8RUQYEwk/f34ZX8UTykN68FwrqAA=="
+    },
+    "statuses@2.0.1": {
+      "integrity": "sha512-RwNA9Z/7PrK06rYLIzFMlaF+l73iwpzsqRIFgbMLbTcLD6cOao82TaWefPXQvB2fOC4AjuYSEndS7N/mTCbkdQ=="
+    },
+    "statuses@2.0.2": {
+      "integrity": "sha512-DvEy55V3DB7uknRo+4iOGT5fP1slR8wQohVdknigZPMpMstaKJQWhwiYBACJE3Ul2pTnATihhBYnRhZQHGBiRw=="
+    },
+    "toidentifier@1.0.1": {
+      "integrity": "sha512-o5sSPKEkg/DIQNmH43V0/uerLrpzVedkUh8tGNvaeXpfpuwjKenlSox/2O/BTlZUtEe+JG7s5YhEz608PlAHRA=="
     },
     "tslib@1.14.1": {
       "integrity": "sha512-Xni35NKzjgMrwevysHTCArtLDpPvye8zV/0E4EyYn43P7/7qvQwPh9BGkHewbMulVntbigmcT7rdX3BNo9wRJg=="
@@ -203,14 +609,34 @@
     "tslib@2.8.1": {
       "integrity": "sha512-oJFu94HQb+KVduSUQL7wnpmqnfmLsOA/nAh6b6EH0wCEoK0/mPeXU6c3wKDV83MkOuHPRHtSXKKU99IBazS/2w=="
     },
+    "tsscmp@1.0.6": {
+      "integrity": "sha512-LxhtAkPDTkVCMQjt2h6eBVY28KCjikZqZfMcC15YBeNjkgUpdCfBu5HoiOTDu86v6smE8yOjyEktJ8hlbANHQA=="
+    },
     "tsyringe@4.10.0": {
       "integrity": "sha512-axr3IdNuVIxnaK5XGEUFTu3YmAQ6lllgrvqfEoR16g/HGnYY/6We4oWENtAnzK6/LpJ2ur9PAb80RBt7/U4ugw==",
       "dependencies": [
         "tslib@1.14.1"
       ]
     },
+    "type-is@2.0.1": {
+      "integrity": "sha512-OZs6gsjF4vMp32qrCbiVSkrFmXtG/AZhY3t0iAMrMBiAZyV9oALtXO8hsrHbMXF9x6L3grlFuwW2oAz7cav+Gw==",
+      "dependencies": [
+        "content-type",
+        "media-typer",
+        "mime-types@3.0.1"
+      ]
+    },
     "undici-types@7.10.0": {
       "integrity": "sha512-t5Fy/nfn+14LuOc2KNYg75vZqClpAiqscVvMygNnlsHBFpSXdJaYtXMcdNLpl/Qvc3P2cB3s6lOV51nqsFq4ag=="
+    },
+    "unpipe@1.0.0": {
+      "integrity": "sha512-pjy2bYhSsufwWlKwPc+l3cN7+wuJlK6uz0YdJEOlQDbl6jo/YlPi4mb8agUkVC8BF7V8NuzeyPNqRksA3hztKQ=="
+    },
+    "urlpattern-polyfill@10.1.0": {
+      "integrity": "sha512-IGjKp/o0NL3Bso1PymYURCJxMPNAf/ILOpendP9f5B6e1rTJgdgiOvgfoT8VxCAdY+Wisb9uhGaJJf3yZ2V9nw=="
+    },
+    "vary@1.1.2": {
+      "integrity": "sha512-BNGbWLfd0eUPabhkXUVm0j8uuvREyTh5ovRa/dyow/BqAbZJyC+5fU+IzQOzmAKzYqYRAISoRhdQr3eIZ/PXqg=="
     }
   },
   "workspace": {
@@ -226,7 +652,9 @@
       },
       "server": {
         "dependencies": [
-          "npm:hono@*"
+          "npm:@whatwg-node/server@~0.10.12",
+          "npm:hono@*",
+          "npm:oidc-provider@^9.5.1"
         ]
       }
     }

--- a/dpop/deno.json
+++ b/dpop/deno.json
@@ -1,0 +1,21 @@
+{
+  "compilerOptions": {
+    "strict": true,
+    "lib": ["deno.ns", "deno.unstable", "dom"]
+  },
+  "imports": {
+    "@std/assert": "jsr:@std/assert@^1.0.0",
+    "@std/encoding": "jsr:@std/encoding@1.0.10"
+  },
+  "tasks": {
+    "check": "deno check mod.ts",
+    "fmt": "deno fmt",
+    "lint": "deno lint"
+  },
+  "fmt": {
+    "include": ["mod.ts", "mod.test.ts"]
+  },
+  "lint": {
+    "include": ["mod.ts", "mod.test.ts"]
+  }
+}

--- a/dpop/mod.test.ts
+++ b/dpop/mod.test.ts
@@ -1,0 +1,137 @@
+import { assert, assertEquals, assertFalse } from "@std/assert";
+import {
+  createDpopProof,
+  generateDpopKeyPair,
+  normalizeHtu,
+  verifyDpopProof,
+} from "./mod.ts";
+
+const exampleUrl = "https://example.com/resource?foo=bar";
+
+Deno.test("normalizeHtu removes fragments and preserves query", () => {
+  assertEquals(
+    normalizeHtu(`${exampleUrl}#fragment`),
+    exampleUrl,
+  );
+});
+
+Deno.test("create and verify DPoP proof", async () => {
+  const keyPair = await generateDpopKeyPair();
+  const proof = await createDpopProof({
+    keyPair,
+    method: "GET",
+    url: `${exampleUrl}#section`,
+    accessToken: "token-value",
+    nonce: "abc123",
+  });
+
+  const result = await verifyDpopProof({
+    proof,
+    method: "GET",
+    url: exampleUrl,
+    accessToken: "token-value",
+    nonce: "abc123",
+  });
+
+  assert(result.valid);
+  assert(result.payload);
+  assertEquals(result.payload.htm, "GET");
+  assertEquals(result.payload.htu, exampleUrl);
+  assert(result.payload.ath);
+  assertEquals(result.payload.nonce, "abc123");
+});
+
+Deno.test("reject mismatched method", async () => {
+  const keyPair = await generateDpopKeyPair();
+  const proof = await createDpopProof({
+    keyPair,
+    method: "POST",
+    url: exampleUrl,
+  });
+
+  const result = await verifyDpopProof({
+    proof,
+    method: "GET",
+    url: exampleUrl,
+  });
+
+  assertFalse(result.valid);
+  assertEquals(result.error, "method-mismatch");
+});
+
+Deno.test("reject mismatched access token hash", async () => {
+  const keyPair = await generateDpopKeyPair();
+  const proof = await createDpopProof({
+    keyPair,
+    method: "GET",
+    url: exampleUrl,
+    accessToken: "correct-token",
+  });
+
+  const result = await verifyDpopProof({
+    proof,
+    method: "GET",
+    url: exampleUrl,
+    accessToken: "wrong-token",
+  });
+
+  assertFalse(result.valid);
+  assertEquals(result.error, "ath-mismatch");
+});
+
+Deno.test("reject stale proof", async () => {
+  const keyPair = await generateDpopKeyPair();
+  const now = Math.floor(Date.now() / 1000);
+  const proof = await createDpopProof({
+    keyPair,
+    method: "GET",
+    url: exampleUrl,
+    iat: now - 1000,
+  });
+
+  const result = await verifyDpopProof({
+    proof,
+    method: "GET",
+    url: exampleUrl,
+    now,
+    maxAgeSeconds: 300,
+  });
+
+  assertFalse(result.valid);
+  assertEquals(result.error, "expired");
+});
+
+Deno.test("detect replay via custom checker", async () => {
+  const seen = new Set<string>();
+  const keyPair = await generateDpopKeyPair();
+  const proof = await createDpopProof({
+    keyPair,
+    method: "GET",
+    url: exampleUrl,
+  });
+
+  const first = await verifyDpopProof({
+    proof,
+    method: "GET",
+    url: exampleUrl,
+    checkReplay: (jti) => {
+      if (seen.has(jti)) {
+        return false;
+      }
+      seen.add(jti);
+      return true;
+    },
+  });
+
+  assert(first.valid);
+
+  const second = await verifyDpopProof({
+    proof,
+    method: "GET",
+    url: exampleUrl,
+    checkReplay: (jti) => seen.has(jti) ? false : (seen.add(jti), true),
+  });
+
+  assertFalse(second.valid);
+  assertEquals(second.error, "replay-detected");
+});

--- a/dpop/mod.ts
+++ b/dpop/mod.ts
@@ -1,0 +1,310 @@
+import { decodeBase64Url, encodeBase64Url } from "@std/encoding/base64url";
+
+const textEncoder = new TextEncoder();
+const textDecoder = new TextDecoder();
+
+const toUint8Array = (input: ArrayBuffer | Uint8Array): Uint8Array =>
+  input instanceof Uint8Array ? input : new Uint8Array(input);
+
+const base64UrlEncode = (input: ArrayBuffer | Uint8Array): string =>
+  encodeBase64Url(toUint8Array(input));
+
+const base64UrlDecode = (input: string): Uint8Array =>
+  new Uint8Array(decodeBase64Url(input));
+
+const sha256Base64Url = async (value: string): Promise<string> => {
+  const data = textEncoder.encode(value);
+  const digest = await crypto.subtle.digest("SHA-256", data);
+  return base64UrlEncode(digest);
+};
+
+const normalizeMethod = (method: string): string => method.trim().toUpperCase();
+
+export const normalizeHtu = (url: string): string => {
+  const parsed = new URL(url);
+  return `${parsed.origin}${parsed.pathname}${parsed.search}`;
+};
+
+export interface GenerateDpopKeyPairOptions {
+  /**
+   * Whether the generated keys should be extractable. Defaults to `true` so the
+   * public key can be embedded in the DPoP proof header.
+   */
+  extractable?: boolean;
+}
+
+export const generateDpopKeyPair = (
+  options: GenerateDpopKeyPairOptions = {},
+): Promise<CryptoKeyPair> =>
+  crypto.subtle.generateKey(
+    {
+      name: "ECDSA",
+      namedCurve: "P-256",
+    },
+    options.extractable ?? true,
+    ["sign", "verify"],
+  ) as Promise<CryptoKeyPair>;
+
+export interface DpopJwtPayload {
+  readonly htm: string;
+  readonly htu: string;
+  readonly jti: string;
+  readonly iat: number;
+  readonly nonce?: string;
+  readonly ath?: string;
+}
+
+export interface CreateDpopProofOptions {
+  readonly keyPair: CryptoKeyPair;
+  readonly method: string;
+  readonly url: string;
+  readonly accessToken?: string;
+  readonly nonce?: string;
+  readonly jti?: string;
+  readonly iat?: number;
+}
+
+const stripPrivateFields = (jwk: JsonWebKey): JsonWebKey => {
+  const { crv, kty, x, y } = jwk;
+  return { crv, kty, x, y };
+};
+
+export const createDpopProof = async (
+  options: CreateDpopProofOptions,
+): Promise<string> => {
+  const method = normalizeMethod(options.method);
+  const htu = normalizeHtu(options.url);
+  const iat = options.iat ?? Math.floor(Date.now() / 1000);
+  const jti = options.jti ?? crypto.randomUUID();
+
+  if (!method) {
+    throw new TypeError("HTTP method is required to create a DPoP proof.");
+  }
+
+  const payload: DpopJwtPayload = {
+    htm: method,
+    htu,
+    iat,
+    jti,
+    ...(options.nonce !== undefined ? { nonce: options.nonce } : {}),
+    ...(options.accessToken
+      ? { ath: await sha256Base64Url(options.accessToken) }
+      : {}),
+  };
+
+  const publicJwk = await crypto.subtle.exportKey(
+    "jwk",
+    options.keyPair.publicKey,
+  );
+
+  const header = {
+    alg: "ES256" as const,
+    typ: "dpop+jwt" as const,
+    jwk: stripPrivateFields(publicJwk),
+  };
+
+  const encodedHeader = base64UrlEncode(
+    textEncoder.encode(JSON.stringify(header)),
+  );
+  const encodedPayload = base64UrlEncode(
+    textEncoder.encode(JSON.stringify(payload)),
+  );
+  const signingInput = `${encodedHeader}.${encodedPayload}`;
+  const signature = await crypto.subtle.sign(
+    { name: "ECDSA", hash: "SHA-256" },
+    options.keyPair.privateKey,
+    textEncoder.encode(signingInput),
+  );
+
+  const encodedSignature = base64UrlEncode(signature);
+  return `${signingInput}.${encodedSignature}`;
+};
+
+export interface VerifyDpopProofOptions {
+  readonly proof: string;
+  readonly method: string;
+  readonly url: string;
+  readonly accessToken?: string;
+  readonly nonce?: string;
+  /** Maximum allowed age (seconds) for the `iat` claim. Defaults to 300s. */
+  readonly maxAgeSeconds?: number;
+  /**
+   * Allowed clock skew (seconds) when comparing the `iat` claim with the
+   * current time. Defaults to 60s.
+   */
+  readonly clockSkewSeconds?: number;
+  /** Optional hook to reject replayed `jti` values. */
+  readonly checkReplay?: (jti: string) => boolean | Promise<boolean>;
+  /**
+   * Allows providing a custom timestamp (in seconds) for deterministic tests.
+   * Defaults to `Math.floor(Date.now() / 1000)`.
+   */
+  readonly now?: number;
+}
+
+export interface VerifyDpopProofResult {
+  readonly valid: boolean;
+  readonly error?: string;
+  readonly payload?: DpopJwtPayload;
+  readonly jwk?: JsonWebKey;
+}
+
+const parseJwtSection = (segment: string) => {
+  const bytes = base64UrlDecode(segment);
+  const decoded = textDecoder.decode(bytes);
+  return JSON.parse(decoded);
+};
+
+const isValidPublicJwk = (jwk: unknown): jwk is JsonWebKey => {
+  if (!jwk || typeof jwk !== "object") {
+    return false;
+  }
+  const record = jwk as Record<string, unknown>;
+  return (
+    record.kty === "EC" &&
+    record.crv === "P-256" &&
+    typeof record.x === "string" &&
+    typeof record.y === "string"
+  );
+};
+
+const timingSafeEqual = (a: string, b: string): boolean => {
+  const aBytes = textEncoder.encode(a);
+  const bBytes = textEncoder.encode(b);
+  if (aBytes.length !== bBytes.length) {
+    return false;
+  }
+  let result = 0;
+  for (let i = 0; i < aBytes.length; i += 1) {
+    result |= aBytes[i]! ^ bBytes[i]!;
+  }
+  return result === 0;
+};
+
+export const verifyDpopProof = async (
+  options: VerifyDpopProofOptions,
+): Promise<VerifyDpopProofResult> => {
+  const parts = options.proof.split(".");
+  if (parts.length !== 3) {
+    return { valid: false, error: "invalid-format" };
+  }
+
+  let header: { alg?: string; typ?: string; jwk?: unknown };
+  let payload: DpopJwtPayload & Record<string, unknown>;
+  try {
+    header = parseJwtSection(parts[0]!) as typeof header;
+    payload = parseJwtSection(parts[1]!) as typeof payload;
+  } catch {
+    return { valid: false, error: "invalid-json" };
+  }
+
+  if (header.typ?.toLowerCase() !== "dpop+jwt") {
+    return { valid: false, error: "invalid-type" };
+  }
+  if (header.alg !== "ES256") {
+    return { valid: false, error: "unsupported-algorithm" };
+  }
+  if (!isValidPublicJwk(header.jwk)) {
+    return { valid: false, error: "invalid-jwk" };
+  }
+
+  const expectedMethod = normalizeMethod(options.method);
+  if (payload.htm?.toUpperCase() !== expectedMethod) {
+    return { valid: false, error: "method-mismatch" };
+  }
+
+  let expectedHtu: string;
+  try {
+    expectedHtu = normalizeHtu(options.url);
+  } catch {
+    return { valid: false, error: "invalid-url" };
+  }
+  if (payload.htu !== expectedHtu) {
+    return { valid: false, error: "url-mismatch" };
+  }
+
+  if (typeof payload.jti !== "string" || !payload.jti) {
+    return { valid: false, error: "invalid-jti" };
+  }
+
+  if (typeof payload.iat !== "number" || !Number.isFinite(payload.iat)) {
+    return { valid: false, error: "invalid-iat" };
+  }
+
+  const maxAge = options.maxAgeSeconds ?? 300;
+  const clockSkew = options.clockSkewSeconds ?? 60;
+  const now = options.now ?? Math.floor(Date.now() / 1000);
+
+  if (payload.iat > now + clockSkew) {
+    return { valid: false, error: "future-iat" };
+  }
+  if (now - payload.iat > maxAge) {
+    return { valid: false, error: "expired" };
+  }
+
+  if (options.nonce !== undefined) {
+    if (payload.nonce !== options.nonce) {
+      return { valid: false, error: "nonce-mismatch" };
+    }
+  }
+
+  if (options.accessToken) {
+    if (typeof payload.ath !== "string") {
+      return { valid: false, error: "missing-ath" };
+    }
+    const expectedAth = await sha256Base64Url(options.accessToken);
+    if (!timingSafeEqual(payload.ath, expectedAth)) {
+      return { valid: false, error: "ath-mismatch" };
+    }
+  }
+
+  if (options.checkReplay) {
+    const ok = await options.checkReplay(payload.jti);
+    if (!ok) {
+      return { valid: false, error: "replay-detected" };
+    }
+  }
+
+  let publicKey: CryptoKey;
+  try {
+    publicKey = await crypto.subtle.importKey(
+      "jwk",
+      header.jwk,
+      {
+        name: "ECDSA",
+        namedCurve: "P-256",
+      },
+      false,
+      ["verify"],
+    );
+  } catch {
+    return { valid: false, error: "invalid-jwk" };
+  }
+
+  const decodedSignature = base64UrlDecode(parts[2]!);
+  const signatureBytes = new Uint8Array(decodedSignature.length);
+  signatureBytes.set(decodedSignature);
+  const signingInput = textEncoder.encode(`${parts[0]!}.${parts[1]!}`);
+  const signatureValid = await crypto.subtle.verify(
+    { name: "ECDSA", hash: "SHA-256" },
+    publicKey,
+    signatureBytes,
+    signingInput,
+  );
+  if (!signatureValid) {
+    return { valid: false, error: "invalid-signature" };
+  }
+
+  return {
+    valid: true,
+    payload: {
+      htm: payload.htm,
+      htu: payload.htu,
+      jti: payload.jti,
+      iat: payload.iat,
+      nonce: payload.nonce,
+      ath: payload.ath,
+    },
+    jwk: header.jwk,
+  };
+};

--- a/hono-middleware/src/index.ts
+++ b/hono-middleware/src/index.ts
@@ -235,7 +235,9 @@ export const createPasskeyMiddleware = (
     c.header("Cache-Control", "no-store");
   };
 
-  const clientJsPromise = Deno.readTextFile(new URL(import.meta.resolve("../_dist/client.js")))
+  const clientJsPromise = Deno.readTextFile(
+    new URL(import.meta.resolve("../_dist/client.js")),
+  );
   routes.get("/client.js", (c) =>
     respond(async () => {
       setNoStore(c);

--- a/server/app.ts
+++ b/server/app.ts
@@ -10,26 +10,18 @@ import {
   type PasskeyUser,
 } from "@passkeys-middleware/hono";
 import { DenoKvPasskeyStore } from "./deno-kv-passkey-store.ts";
-import process from "node:process";
 import { createOidcRouter } from "./oidc-router.ts";
+import { loadEnv } from "./load-env.ts";
 
-const rpID = process.env.RP_ID ?? "localhost";
-const rpName = process.env.RP_NAME ?? "Passkeys Middleware Demo";
-const defaultOrigin = process.env.PUBLIC_ORIGIN?.trim() ??
-  "http://localhost:8000";
-const normalizedOrigin = defaultOrigin.endsWith("/")
-  ? defaultOrigin.slice(0, -1)
-  : defaultOrigin;
-const oidcIssuer = process.env.OIDC_ISSUER?.trim() ??
-  `${normalizedOrigin}/oidc`;
-const oidcClientId = process.env.OIDC_CLIENT_ID?.trim() ?? "demo-client";
-const oidcClientName = process.env.OIDC_CLIENT_NAME?.trim() ??
-  "Passkeys Demo Client";
-const oidcRedirectUri = process.env.OIDC_CLIENT_REDIRECT_URI?.trim() ??
-  `${normalizedOrigin}/demo.html`;
-const oidcCookieKeys = process.env.OIDC_COOKIE_KEYS?.split(",")
-  .map((key) => key.trim())
-  .filter((key) => key.length > 0);
+const {
+  rpID,
+  rpName,
+  oidcIssuer,
+  oidcClientId,
+  oidcClientName,
+  oidcClientRedirectUri,
+  oidcCookieKeys,
+} = loadEnv();
 
 const app = new Hono();
 const credentialStore = await DenoKvPasskeyStore.create();
@@ -96,7 +88,7 @@ const oidcRouter = createOidcRouter({
   client: {
     id: oidcClientId,
     name: oidcClientName,
-    redirectUris: [oidcRedirectUri],
+    redirectUris: [oidcClientRedirectUri],
   },
   credentialStore,
   passkeySessionCookieName: SESSION_COOKIE_NAME,

--- a/server/deno.json
+++ b/server/deno.json
@@ -1,7 +1,9 @@
 {
   "imports": {
+    "@whatwg-node/server": "npm:@whatwg-node/server@^0.10.12",
     "hono": "npm:hono",
-    "@passkeys-middleware/hono": "../hono-middleware/mod.ts"
+    "@passkeys-middleware/hono": "../hono-middleware/mod.ts",
+    "oidc-provider": "npm:oidc-provider@^9.5.1"
   },
   "tasks": {
     "serve": "deno serve --allow-env --allow-net --allow-read=.. deno-server.ts",

--- a/server/load-env.ts
+++ b/server/load-env.ts
@@ -1,0 +1,55 @@
+import process from "node:process";
+
+const trimOrUndefined = (value: string | undefined): string | undefined => {
+  if (!value) {
+    return undefined;
+  }
+  const trimmed = value.trim();
+  return trimmed.length > 0 ? trimmed : undefined;
+};
+
+export interface EnvConfig {
+  rpID: string;
+  rpName: string;
+  publicOrigin: string;
+  oidcIssuer: string;
+  oidcClientId: string;
+  oidcClientName: string;
+  oidcClientRedirectUri: string;
+  oidcCookieKeys: string[];
+}
+
+export const loadEnv = (): EnvConfig => {
+  const rpID = trimOrUndefined(process.env.RP_ID) ?? "localhost";
+  const rpName = trimOrUndefined(process.env.RP_NAME) ??
+    "Passkeys Middleware Demo";
+  const defaultOrigin = trimOrUndefined(process.env.PUBLIC_ORIGIN) ??
+    "http://localhost:8000";
+  const publicOrigin = defaultOrigin.endsWith("/")
+    ? defaultOrigin.slice(0, -1)
+    : defaultOrigin;
+  const oidcIssuer = trimOrUndefined(process.env.OIDC_ISSUER) ??
+    `${publicOrigin}/oidc`;
+  const oidcClientId = trimOrUndefined(process.env.OIDC_CLIENT_ID) ??
+    "demo-client";
+  const oidcClientName = trimOrUndefined(process.env.OIDC_CLIENT_NAME) ??
+    "Passkeys Demo Client";
+  const oidcClientRedirectUri =
+    trimOrUndefined(process.env.OIDC_CLIENT_REDIRECT_URI) ??
+      `${publicOrigin}/demo.html`;
+  const oidcCookieKeys =
+    trimOrUndefined(process.env.OIDC_COOKIE_KEYS)?.split(",")
+      .map((key) => key.trim())
+      .filter((key) => key.length > 0) ?? [];
+
+  return {
+    rpID,
+    rpName,
+    publicOrigin,
+    oidcIssuer,
+    oidcClientId,
+    oidcClientName,
+    oidcClientRedirectUri,
+    oidcCookieKeys,
+  };
+};

--- a/server/oidc-router.ts
+++ b/server/oidc-router.ts
@@ -1,0 +1,225 @@
+import { Hono } from "hono";
+import Provider from "oidc-provider";
+import { createServerAdapter } from "@whatwg-node/server";
+import type { PasskeyUser } from "@passkeys-middleware/hono";
+import type { KoaContextWithOIDC } from "oidc-provider";
+
+import type { DenoKvPasskeyStore } from "./deno-kv-passkey-store.ts";
+
+export type OidcRouterOptions = {
+  issuer: string;
+  client: {
+    id: string;
+    redirectUris: string[];
+    name?: string;
+  };
+  credentialStore: DenoKvPasskeyStore;
+  passkeySessionCookieName: string;
+  cookieKeys?: string[];
+};
+
+const html = (content: string) =>
+  `<!DOCTYPE html><html lang="en"><head><meta charset="utf-8" /><meta name="viewport" content="width=device-width, initial-scale=1" /><title>OIDC Sign-in Required</title><style>body{font-family:system-ui, -apple-system, "Segoe UI", sans-serif;margin:0;padding:2rem;background:#f8fafc;color:#0f172a;}main{max-width:560px;margin:0 auto;background:#fff;padding:2rem;border-radius:16px;box-shadow:0 25px 45px rgba(15,23,42,0.12);}h1{font-size:1.6rem;margin-top:0;}p{line-height:1.6;}a.button{display:inline-flex;align-items:center;justify-content:center;padding:0.65rem 1.4rem;background:#2563eb;color:#fff;border-radius:999px;font-weight:600;text-decoration:none;margin-top:1rem;}a.button.secondary{background:#0f172a1a;color:#1e293b;}code{background:#f1f5f9;padding:0.15rem 0.35rem;border-radius:6px;font-size:0.95rem;}</style></head><body><main>${content}</main></body></html>`;
+
+const createLoginRequiredPage = () =>
+  html(
+    `<h1>パスキーでサインインしてください</h1><p>この OpenID Connect のフローを続けるには、先にパスキーでサインインする必要があります。</p><p>別タブで <code>/</code> または <code>/demo.html</code> のページからサインインしてから、このページに戻ってください。</p><a class="button" href="/demo.html">デモページへ戻る</a><a class="button secondary" href="/">トップへ</a>`,
+  );
+
+const createAccountMissingPage = () =>
+  html(
+    `<h1>アカウントが見つかりません</h1><p>パスキーのセッションは存在しますが、対応するアカウントが見つかりませんでした。再度サインインしてください。</p><a class="button" href="/demo.html">サインインする</a>`,
+  );
+
+const createUnexpectedPromptPage = (prompt: string) =>
+  html(
+    `<h1>リクエストを続行できません</h1><p>対応していないプロンプト <code>${prompt}</code> が要求されました。</p><a class="button" href="/demo.html">デモページに戻る</a>`,
+  );
+
+export const createOidcRouter = (
+  options: OidcRouterOptions,
+): Hono => {
+  const {
+    issuer,
+    client,
+    credentialStore,
+    passkeySessionCookieName,
+    cookieKeys,
+  } = options;
+
+  const provider = new Provider(issuer, {
+    cookies: {
+      keys: cookieKeys && cookieKeys.length > 0
+        ? cookieKeys
+        : [crypto.randomUUID()],
+    },
+    clients: [
+      {
+        client_id: client.id,
+        redirect_uris: client.redirectUris,
+        response_types: ["id_token"],
+        grant_types: ["implicit"],
+        token_endpoint_auth_method: "none",
+        client_name: client.name,
+      },
+    ],
+    interactions: {
+      url: (_ctx, interaction) => `/oidc/interactions/${interaction.uid}`,
+    },
+    features: {
+      devInteractions: { enabled: false },
+      rpInitiatedLogout: { enabled: true },
+    },
+    claims: {
+      openid: ["sub"],
+      profile: ["name", "preferred_username"],
+    },
+    findAccount: async (_ctx, id: string) => {
+      const account = await credentialStore.getUserById(id);
+      if (!account) return undefined;
+      return {
+        accountId: id,
+        async claims(_use, scope) {
+          const user = await credentialStore.getUserById(id);
+          if (!user) return { sub: id };
+          const result: Record<string, unknown> = {
+            sub: id,
+          };
+          if (!scope || scope.includes("profile")) {
+            result.name = user.displayName ?? user.username;
+            result.preferred_username = user.username;
+          }
+          return result;
+        },
+      };
+    },
+  });
+
+  provider.proxy = true;
+
+  const readSessionId = (ctx: KoaContextWithOIDC): string | null =>
+    ctx.cookies.get(passkeySessionCookieName)?.trim() ?? null;
+
+  const clearPasskeySession = (ctx: KoaContextWithOIDC) => {
+    ctx.cookies.set(passkeySessionCookieName, "", {
+      httpOnly: true,
+      sameSite: "lax",
+      path: "/",
+      secure: ctx.secure,
+      maxAge: 0,
+    });
+  };
+
+  const getPasskeyUser = async (
+    sessionId: string,
+  ): Promise<PasskeyUser | null> => {
+    try {
+      const user = await credentialStore.getUserById(sessionId);
+      return user ?? null;
+    } catch {
+      return null;
+    }
+  };
+
+  provider.use(async (ctx, next) => {
+    if (!ctx.path.startsWith("/interactions/")) {
+      return next();
+    }
+
+    const details = await provider.interactionDetails(ctx.req, ctx.res);
+    if (details.prompt.name === "login") {
+      const sessionId = readSessionId(ctx);
+      if (!sessionId) {
+        ctx.status = 401;
+        ctx.body = createLoginRequiredPage();
+        return;
+      }
+      const user = await getPasskeyUser(sessionId);
+      if (!user) {
+        clearPasskeySession(ctx);
+        ctx.status = 401;
+        ctx.body = createAccountMissingPage();
+        return;
+      }
+      const result = {
+        login: {
+          accountId: user.id,
+          ts: Math.floor(Date.now() / 1000),
+          remember: true,
+          amr: ["passkey"],
+          acr: "urn:passkeys:assurance:basic",
+        },
+      };
+      await provider.interactionFinished(ctx.req, ctx.res, result, {
+        mergeWithLastSubmission: false,
+      });
+      return;
+    }
+
+    if (details.prompt.name === "consent") {
+      const { Grant } = provider;
+      const accountId = details.session?.accountId;
+      if (!accountId) {
+        ctx.status = 401;
+        ctx.body = createLoginRequiredPage();
+        return;
+      }
+      let grant = details.grantId
+        ? await Grant.find(details.grantId)
+        : undefined;
+      if (!grant) {
+        grant = new Grant({
+          accountId,
+          clientId: details.params.client_id as string,
+        });
+      }
+
+      if (details.missingOIDCScope?.length) {
+        grant.addOIDCScope(details.missingOIDCScope.join(" "));
+      }
+
+      if (details.missingOIDCClaims?.length) {
+        grant.addOIDCClaims(details.missingOIDCClaims);
+      }
+
+      if (details.missingResourceScopes) {
+        for (
+          const [indicator, scopes] of Object.entries(
+            details.missingResourceScopes,
+          )
+        ) {
+          grant.addResourceScope(indicator, scopes.join(" "));
+        }
+      }
+
+      const grantId = await grant.save();
+
+      const consent = details.grantId
+        ? { grantId }
+        : { grantId, scope: details.params.scope };
+
+      await provider.interactionFinished(ctx.req, ctx.res, { consent }, {
+        mergeWithLastSubmission: true,
+      });
+      return;
+    }
+
+    ctx.status = 400;
+    ctx.body = createUnexpectedPromptPage(details.prompt.name);
+  });
+
+  const adapter = createServerAdapter(provider.callback());
+  const router = new Hono();
+
+  router.use(async (c, next) => {
+    c.header("Cache-Control", "no-store");
+    await next();
+  });
+
+  router.all("*", async (c) => {
+    const response = await adapter.fetch(c.req.raw);
+    return response;
+  });
+
+  return router;
+};

--- a/server/static/demo.html
+++ b/server/static/demo.html
@@ -1,0 +1,589 @@
+<!DOCTYPE html>
+<html lang="ja">
+  <head>
+    <meta charset="utf-8" />
+    <meta name="viewport" content="width=device-width, initial-scale=1" />
+    <title>OIDC デモ | Passkeys Middleware</title>
+    <style>
+      :root {
+        color-scheme: light dark;
+        font-family:
+          "Inter", system-ui, -apple-system, "Segoe UI", sans-serif;
+        line-height: 1.6;
+        --surface: rgba(255, 255, 255, 0.92);
+        --surface-strong: rgba(255, 255, 255, 0.98);
+        --surface-muted: rgba(15, 23, 42, 0.08);
+        --text: #0f172a;
+        --text-muted: rgba(15, 23, 42, 0.65);
+        --primary: #2563eb;
+        --primary-strong: #1d4ed8;
+        --border: rgba(15, 23, 42, 0.12);
+        --danger: #dc2626;
+        --radius: 18px;
+      }
+      @media (prefers-color-scheme: dark) {
+        :root {
+          --surface: rgba(15, 23, 42, 0.86);
+          --surface-strong: rgba(15, 23, 42, 0.95);
+          --surface-muted: rgba(148, 163, 184, 0.12);
+          --text: rgba(226, 232, 240, 0.94);
+          --text-muted: rgba(148, 163, 184, 0.82);
+          --border: rgba(148, 163, 184, 0.22);
+        }
+        body {
+          background:
+            radial-gradient(
+              circle at top left,
+              rgba(59, 130, 246, 0.26),
+              transparent 55%
+            ),
+            radial-gradient(
+            circle at bottom right,
+            rgba(16, 185, 129, 0.24),
+            transparent 55%
+          ),
+            linear-gradient(180deg, #020617, #0f172a);
+        }
+      }
+      body {
+        margin: 0;
+        padding: 3rem 1.5rem 4rem;
+        background:
+          radial-gradient(
+            circle at top left,
+            rgba(59, 130, 246, 0.18),
+            transparent 55%
+          ),
+          radial-gradient(
+          circle at bottom right,
+          rgba(16, 185, 129, 0.16),
+          transparent 55%
+        ),
+          linear-gradient(180deg, #f1f5f9, #e2e8f0);
+        color: var(--text);
+        min-height: 100vh;
+      }
+      main {
+        max-width: 920px;
+        margin: 0 auto;
+        display: grid;
+        gap: 2.2rem;
+      }
+      .card {
+        background: var(--surface);
+        border-radius: var(--radius);
+        padding: clamp(1.6rem, 1.2rem + 1vw, 2.2rem);
+        box-shadow: 0 24px 48px rgba(15, 23, 42, 0.12);
+        border: 1px solid var(--border);
+        display: grid;
+        gap: 1.35rem;
+      }
+      h1 {
+        margin: 0 0 0.5rem;
+        font-size: clamp(2rem, 1.6rem + 1vw, 2.6rem);
+      }
+      h2 {
+        margin: 0;
+        font-size: clamp(1.4rem, 1.25rem + 0.4vw, 1.75rem);
+      }
+      p {
+        margin: 0;
+        color: var(--text-muted);
+      }
+      .hint {
+        margin: 0;
+        color: var(--text-muted);
+        font-size: 0.9rem;
+        min-height: 1.2rem;
+      }
+      form {
+        display: grid;
+        gap: 0.9rem;
+      }
+      label {
+        display: grid;
+        gap: 0.45rem;
+        font-weight: 600;
+        color: var(--text);
+      }
+      input[type="text"],
+      input[type="password"],
+      input[type="search"],
+      input[type="url"],
+      input[type="email"] {
+        appearance: none;
+        border-radius: 12px;
+        border: 1px solid var(--border);
+        padding: 0.75rem 1rem;
+        font-size: 1rem;
+        background: var(--surface-strong);
+        color: inherit;
+      }
+      input:focus {
+        outline: 3px solid rgba(37, 99, 235, 0.2);
+        border-color: rgba(37, 99, 235, 0.65);
+      }
+      button {
+        appearance: none;
+        border: none;
+        border-radius: 999px;
+        padding: 0.7rem 1.5rem;
+        font-size: 1rem;
+        font-weight: 600;
+        cursor: pointer;
+        background: var(--primary);
+        color: #fff;
+        display: inline-flex;
+        align-items: center;
+        justify-content: center;
+        gap: 0.4rem;
+        transition: background 0.15s ease, transform 0.15s ease;
+      }
+      button:hover {
+        background: var(--primary-strong);
+        transform: translateY(-1px);
+      }
+      button.secondary {
+        background: var(--surface-muted);
+        color: var(--text);
+      }
+      button.secondary:hover {
+        background: rgba(37, 99, 235, 0.18);
+        color: var(--primary-strong);
+      }
+      button.danger {
+        background: var(--danger);
+      }
+      button:disabled {
+        opacity: 0.65;
+        cursor: not-allowed;
+        transform: none;
+      }
+      .actions {
+        display: flex;
+        flex-wrap: wrap;
+        gap: 0.75rem;
+      }
+      .status {
+        border-radius: 14px;
+        padding: 0.75rem 1rem;
+        background: var(--surface-muted);
+        border: 1px solid transparent;
+        font-weight: 500;
+      }
+      .status[data-status="error"] {
+        background: rgba(248, 113, 113, 0.16);
+        border-color: rgba(248, 113, 113, 0.25);
+        color: var(--danger);
+      }
+      .status[data-status="success"] {
+        background: rgba(34, 197, 94, 0.16);
+        border-color: rgba(34, 197, 94, 0.24);
+        color: #047857;
+      }
+      pre {
+        margin: 0;
+        padding: 1rem;
+        border-radius: 14px;
+        background: rgba(15, 23, 42, 0.85);
+        color: #e2e8f0;
+        overflow-x: auto;
+        font-size: 0.95rem;
+      }
+      code {
+        font-family:
+          "JetBrains Mono", "Fira Code", ui-monospace, SFMono-Regular, Menlo,
+          Monaco, Consolas, "Liberation Mono", "Courier New", monospace;
+      }
+      .grid-two {
+        display: grid;
+        gap: 1.5rem;
+      }
+      @media (min-width: 720px) {
+        .grid-two {
+          grid-template-columns: repeat(2, minmax(0, 1fr));
+        }
+      }
+    </style>
+  </head>
+  <body>
+    <main>
+      <section class="card">
+        <div>
+          <h1>Passkeys × OIDC デモ</h1>
+          <p>
+            パスキーで認証したユーザーを <abbr title="OpenID Connect"
+            >OIDC</abbr>
+            プロバイダーとして公開し、サンプルクライアントからログインできるデモです。
+          </p>
+        </div>
+        <div class="status" id="session-status" data-status="info">
+          セッションを確認しています…
+        </div>
+        <div class="actions">
+          <button class="secondary" id="refresh-session">
+            セッション再読込
+          </button>
+          <button class="danger" id="logout-button">サインアウト</button>
+        </div>
+      </section>
+
+      <section class="card">
+        <h2>パスキーでアカウントを用意</h2>
+        <div class="grid-two">
+          <form id="register-form">
+            <h3>新規登録</h3>
+            <label>
+              ユーザー名
+              <input
+                type="text"
+                id="register-username"
+                autocomplete="username"
+                required
+              />
+            </label>
+            <label>
+              表示名
+              <input
+                type="text"
+                id="register-display-name"
+                autocomplete="name"
+              />
+            </label>
+            <label>
+              パスキーのニックネーム
+              <input
+                type="text"
+                id="register-nickname"
+                autocomplete="off"
+                required
+              />
+            </label>
+            <button type="submit" id="register-submit">パスキーを登録</button>
+            <p class="hint" id="register-hint"></p>
+          </form>
+
+          <form id="login-form">
+            <h3>パスキーでサインイン</h3>
+            <label>
+              ユーザー名
+              <input
+                type="text"
+                id="login-username"
+                autocomplete="username"
+                required
+              />
+            </label>
+            <button type="submit" id="login-submit">パスキーで認証</button>
+            <p class="hint" id="login-hint"></p>
+          </form>
+        </div>
+      </section>
+
+      <section class="card">
+        <h2>OIDC フロー</h2>
+        <p>
+          サインイン済みのユーザーとして OIDC
+          認可エンドポイントにリダイレクトします。 応答では <code
+          >id_token</code> を受け取り、このページでデコードして表示します。
+        </p>
+        <div class="actions">
+          <button id="start-oidc">OIDC ログインを開始</button>
+          <button class="secondary" id="clear-id-token">
+            トークン表示をクリア
+          </button>
+        </div>
+        <div id="oidc-status" class="status" data-status="info">
+          準備完了
+        </div>
+        <div id="id-token-view" hidden>
+          <h3>ID トークン</h3>
+          <pre id="id-token-raw"></pre>
+          <h3>デコード結果</h3>
+          <pre id="id-token-decoded"></pre>
+        </div>
+      </section>
+    </main>
+
+    <script type="module">
+      import { createClient } from "/webauthn/client.js";
+
+      const passkeyClient = createClient({ mountPath: "/webauthn" });
+
+      const sessionStatus = document.getElementById("session-status");
+      const refreshSessionButton = document.getElementById(
+        "refresh-session",
+      );
+      const logoutButton = document.getElementById("logout-button");
+      const registerForm = document.getElementById("register-form");
+      const registerUsername = document.getElementById(
+        "register-username",
+      );
+      const registerDisplayName = document.getElementById(
+        "register-display-name",
+      );
+      const registerNickname = document.getElementById(
+        "register-nickname",
+      );
+      const registerHint = document.getElementById("register-hint");
+      const registerSubmit = document.getElementById("register-submit");
+      const loginForm = document.getElementById("login-form");
+      const loginUsername = document.getElementById("login-username");
+      const loginHint = document.getElementById("login-hint");
+      const loginSubmit = document.getElementById("login-submit");
+      const startOidcButton = document.getElementById("start-oidc");
+      const clearIdTokenButton = document.getElementById(
+        "clear-id-token",
+      );
+      const oidcStatus = document.getElementById("oidc-status");
+      const idTokenView = document.getElementById("id-token-view");
+      const idTokenRaw = document.getElementById("id-token-raw");
+      const idTokenDecoded = document.getElementById(
+        "id-token-decoded",
+      );
+
+      const storageKeys = {
+        username: "demo.passkeys.username",
+        oidcState: "demo.oidc.state",
+        idToken: "demo.oidc.idToken",
+      };
+
+      const setSessionStatus = (message, status = "info") => {
+        sessionStatus.textContent = message;
+        sessionStatus.dataset.status = status;
+      };
+
+      const setOidcStatus = (message, status = "info") => {
+        oidcStatus.textContent = message;
+        oidcStatus.dataset.status = status;
+      };
+
+      const persistUsername = (username) => {
+        if (username) {
+          localStorage.setItem(storageKeys.username, username);
+        }
+      };
+
+      const restoreUsername = () => {
+        const value = localStorage.getItem(storageKeys.username) ?? "";
+        registerUsername.value = value;
+        loginUsername.value = value;
+        if (value) {
+          registerNickname.value = `${value} の端末`;
+        }
+      };
+
+      const decodeJwt = (token) => {
+        try {
+          const [headerB64, payloadB64] = token.split(".");
+          const decode = (segment) =>
+            JSON.parse(
+              atob(segment.replace(/-/g, "+").replace(/_/g, "/")),
+            );
+          return {
+            header: decode(headerB64),
+            payload: decode(payloadB64),
+          };
+        } catch (error) {
+          console.error("Failed to decode token", error);
+          return null;
+        }
+      };
+
+      const renderIdToken = (token) => {
+        if (!token) {
+          idTokenView.hidden = true;
+          idTokenRaw.textContent = "";
+          idTokenDecoded.textContent = "";
+          return;
+        }
+        idTokenView.hidden = false;
+        idTokenRaw.textContent = token;
+        const decoded = decodeJwt(token);
+        idTokenDecoded.textContent = decoded
+          ? JSON.stringify(decoded, null, 2)
+          : "デコードに失敗しました";
+      };
+
+      const refreshSession = async () => {
+        try {
+          const response = await fetch("/session", {
+            headers: { Accept: "application/json" },
+          });
+          if (!response.ok) {
+            throw new Error(`ステータス ${response.status}`);
+          }
+          const session = await response.json();
+          if (session?.isAuthenticated && session.user) {
+            const message = `サインイン中: ${
+              session.user.displayName ?? session.user.username
+            }`;
+            setSessionStatus(message, "success");
+          } else {
+            setSessionStatus("まだサインインしていません", "info");
+          }
+        } catch (error) {
+          console.error(error);
+          setSessionStatus(
+            "セッション情報を取得できませんでした",
+            "error",
+          );
+        }
+      };
+
+      const handleRegister = async (event) => {
+        event.preventDefault();
+        registerHint.textContent = "";
+        registerHint.style.color = "var(--text-muted)";
+        const username = registerUsername.value.trim();
+        if (!username) {
+          registerHint.textContent = "ユーザー名を入力してください";
+          return;
+        }
+        const nickname = registerNickname.value.trim();
+        if (!nickname) {
+          registerHint.textContent =
+            "パスキーのニックネームを入力してください";
+          return;
+        }
+        try {
+          registerSubmit.disabled = true;
+          await passkeyClient.register({
+            username,
+            displayName: registerDisplayName.value.trim() || username,
+            nickname,
+          });
+          persistUsername(username);
+          registerHint.textContent = "パスキーを登録しました";
+          registerHint.style.color = "#047857";
+          await refreshSession();
+        } catch (error) {
+          console.error(error);
+          registerHint.textContent = error?.message ??
+            "登録に失敗しました";
+          registerHint.style.color = "var(--danger)";
+        } finally {
+          registerSubmit.disabled = false;
+        }
+      };
+
+      const handleLogin = async (event) => {
+        event.preventDefault();
+        loginHint.textContent = "";
+        loginHint.style.color = "var(--text-muted)";
+        const username = loginUsername.value.trim();
+        if (!username) {
+          loginHint.textContent = "ユーザー名を入力してください";
+          return;
+        }
+        try {
+          loginSubmit.disabled = true;
+          await passkeyClient.authenticate({ username });
+          persistUsername(username);
+          loginHint.textContent = "サインインしました";
+          loginHint.style.color = "#047857";
+          await refreshSession();
+        } catch (error) {
+          console.error(error);
+          loginHint.textContent = error?.message ??
+            "サインインに失敗しました";
+          loginHint.style.color = "var(--danger)";
+        } finally {
+          loginSubmit.disabled = false;
+        }
+      };
+
+      const handleLogout = async () => {
+        try {
+          await fetch("/session/logout", { method: "POST" });
+          setSessionStatus("サインアウトしました", "info");
+          await refreshSession();
+        } catch (error) {
+          console.error(error);
+          setSessionStatus("サインアウトに失敗しました", "error");
+        }
+      };
+
+      const startOidc = () => {
+        setOidcStatus("認可サーバーへリダイレクトします…");
+        const state = crypto.randomUUID();
+        sessionStorage.setItem(storageKeys.oidcState, state);
+        const redirectUri = new URL(window.location.href);
+        redirectUri.hash = "";
+        const authorizeUrl = new URL(
+          "/oidc/auth",
+          window.location.origin,
+        );
+        authorizeUrl.searchParams.set("client_id", "demo-client");
+        authorizeUrl.searchParams.set("redirect_uri", redirectUri.href);
+        authorizeUrl.searchParams.set("response_type", "id_token");
+        authorizeUrl.searchParams.set("scope", "openid profile");
+        authorizeUrl.searchParams.set("state", state);
+        authorizeUrl.searchParams.set("nonce", crypto.randomUUID());
+        window.location.assign(authorizeUrl);
+      };
+
+      const processOidcCallback = () => {
+        if (!window.location.hash) {
+          const storedToken = sessionStorage.getItem(
+            storageKeys.idToken,
+          );
+          if (storedToken) {
+            renderIdToken(storedToken);
+          }
+          return;
+        }
+        const params = new URLSearchParams(
+          window.location.hash.slice(1),
+        );
+        window.history.replaceState(
+          {},
+          document.title,
+          window.location.pathname,
+        );
+        if (params.get("error")) {
+          setOidcStatus(
+            `エラー: ${
+              params.get("error_description") ?? params.get("error")
+            }`,
+            "error",
+          );
+          return;
+        }
+        const state = params.get("state");
+        const expectedState = sessionStorage.getItem(
+          storageKeys.oidcState,
+        );
+        if (expectedState && state !== expectedState) {
+          setOidcStatus("state が一致しません", "error");
+          return;
+        }
+        const token = params.get("id_token");
+        if (!token) {
+          setOidcStatus("id_token が返されませんでした", "error");
+          return;
+        }
+        sessionStorage.removeItem(storageKeys.oidcState);
+        sessionStorage.setItem(storageKeys.idToken, token);
+        setOidcStatus("ID トークンを受信しました", "success");
+        renderIdToken(token);
+      };
+
+      clearIdTokenButton.addEventListener("click", () => {
+        sessionStorage.removeItem(storageKeys.idToken);
+        renderIdToken("");
+        setOidcStatus("トークン表示をクリアしました", "info");
+      });
+
+      refreshSessionButton.addEventListener("click", refreshSession);
+      logoutButton.addEventListener("click", handleLogout);
+      registerForm.addEventListener("submit", handleRegister);
+      loginForm.addEventListener("submit", handleLogin);
+      startOidcButton.addEventListener("click", startOidc);
+
+      restoreUsername();
+      processOidcCallback();
+      refreshSession();
+    </script>
+  </body>
+</html>


### PR DESCRIPTION
## Summary
- add an oidc-provider backed router that trusts passkey sessions and mounts at `/oidc`
- wire the router into the server with environment-based configuration defaults and expose a demo route
- create a new demo page that offers passkey registration/login and drives an example OIDC implicit login flow

## Testing
- `deno lint`
- `DENO_TLS_CA_STORE=system deno test -P`


------
https://chatgpt.com/codex/tasks/task_e_68da7d81a4d88327bc097207d7708635